### PR TITLE
Add optional image to popup content

### DIFF
--- a/src/components/PopupContent.jsx
+++ b/src/components/PopupContent.jsx
@@ -11,6 +11,7 @@ export default function PopupContent({
   isDisabled,
   isLoading,
   infoOnClick,
+  image
 }) {
   return (
     <div
@@ -19,7 +20,11 @@ export default function PopupContent({
         boxShadow: "0 0 40px #413E6a",
       }}
     >
-      <div className="pt-5 pr-5 pl-5 text-2xl flex gap-4">
+      {image && <div className="border w-28 h-28 -mt-14" style={{ borderColor: COLORS.Purple }}>
+        <img src={image} alt="" />
+      </div>}
+      <div className="bg-[#3A403C] h-[1px] w-full"></div>
+      <div className="pr-5 pl-5 text-2xl flex gap-4">
         <div>{title}</div>
         {infoOnClick && (
           <Icon onClick={infoOnClick}>


### PR DESCRIPTION
- Added an optional prop that takes an image object
- If the image is passed to PopupContent, it renders it in a purple border

Design:

<img width="752" alt="Screenshot 2023-01-03 at 5 33 25 PM" src="https://user-images.githubusercontent.com/45239208/210389252-4e94cbc1-7e2d-4ddc-a340-5287a4705513.png">

Implementation:

<img width="606" alt="Screenshot 2023-01-03 at 5 35 46 PM" src="https://user-images.githubusercontent.com/45239208/210389661-45b40c77-0df3-4e52-9257-5e3760f2d064.png">

This is just a demo and no actual images were added to the Withdraw modal
