### PR TITLE
Add negative margin to liquidation risk warning span

### DIFF
--- a/src/components/NFT.jsx
+++ b/src/components/NFT.jsx
@@ -236,7 +236,7 @@ export default function NFT({
               </div>
               {status !== STATUS.RISK_FREE && (
                 <div className=" flex justify-end items-end  text-sm  ">
-                  <div className="bg-[#800101] text-sm p-1 mt-6">
+                  <div className="bg-[#800101] text-sm p-1 -mb-4 -mr-4 mt-9">
                     {status === STATUS.AT_LIQUIDATION_RISK && (
                       <span>Liqudation Risk</span>
                     )}


### PR DESCRIPTION
- Placed Liquidation Risk span in the very bottom right.

Design:

<img width="952" alt="Screenshot 2023-01-03 at 9 02 33 AM" src="https://user-images.githubusercontent.com/45239208/210389942-c7f0aac4-b1a7-455a-90d8-4bffae4faea2.png">

Implementation:

<img width="1015" alt="Screenshot 2023-01-03 at 9 02 59 AM" src="https://user-images.githubusercontent.com/45239208/210389976-54c2ded1-f59c-452c-8d07-f7350b87a6c2.png">
